### PR TITLE
Editado verificaNomeTabela e procuraAtributoFK, liberado memorias

### DIFF
--- a/buffend.c
+++ b/buffend.c
@@ -295,8 +295,10 @@ int verificaNomeTabela(char *nomeTabela)
 
     FILE *dicionario;
     char *tupla = (char *)malloc(sizeof(char)*TAMANHO_NOME_TABELA);
-    if((dicionario = fopen("fs_object.dat","a+b")) == NULL)
+    if((dicionario = fopen("fs_object.dat","a+b")) == NULL){
+		free(tupla);
         return ERRO_ABRIR_ARQUIVO;
+    }
 
     while(fgetc (dicionario) != EOF){
         fseek(dicionario, -1, 1);
@@ -304,7 +306,7 @@ int verificaNomeTabela(char *nomeTabela)
         fread(tupla, sizeof(char), TAMANHO_NOME_TABELA, dicionario); //Lê somente o nome da tabela
 
         if(strcmp(tupla, nomeTabela) == 0){ // Verifica se o nome dado pelo usuario existe no dicionario de dados.
-            
+            free(tupla);
             return 1;
         }
         
@@ -1055,6 +1057,9 @@ tp_table *procuraAtributoFK(struct fs_objects objeto){
 
     if((schema = fopen("fs_schema.dat", "a+b")) == NULL){
         printf("Erro GRAVE ao abrir o ESQUEMA.\nAbortando...\n");
+        free(tupla);
+		free(esquema);
+		free(vetEsqm);
         exit(1);
     }
     
@@ -1087,6 +1092,8 @@ tp_table *procuraAtributoFK(struct fs_objects objeto){
             }
         }
     }
+    free(tupla);
+	free(esquema);
 
     return vetEsqm;
 }


### PR DESCRIPTION
Foi verificado nestas funções problemas de vazamento de memória, conforme issues, foram adicionados as chamadas de função free(), com os devidos parâmetros, para a liberação desta memória que foi alocada anteriormente e não mais usada, agora liberada.